### PR TITLE
8 - AWS profile no longer being ignored when provided

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,33 +1,9 @@
 {
   "name": "serverless-api-gateway-caching",
-  "version": "1.1.0",
+  "version": "1.1.1-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@sinonjs/commons": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
-      "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
-      "dev": true,
-      "requires": {
-        "samsam": "1.3.0"
-      }
-    },
-    "@sinonjs/samsam": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
-      "integrity": "sha512-D7VxhADdZbDJ0HjUTMnSQ5xIGb4H2yWpg8k9Sf1T08zfFiQYlaxM8LZydpR4FQ2E6LZJX8IlabNZ5io4vdChwg==",
-      "dev": true
-    },
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -40,43 +16,11 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "aws-sdk": {
-      "version": "2.310.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.310.0.tgz",
-      "integrity": "sha512-3mIubGpER5h3bGdAaI9/Vy7JQVW9Hmp9hdiCelaE/wNaGFigs1lY/Gt+y9ie80zXW+T5o4LpXjrmqPyK8xaWmQ==",
-      "requires": {
-        "buffer": "4.9.1",
-        "events": "1.1.1",
-        "ieee754": "1.1.8",
-        "jmespath": "0.15.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "uuid": "3.1.0",
-        "xml2js": "0.4.19"
-      }
-    },
-    "aws-sdk-mock": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-4.1.0.tgz",
-      "integrity": "sha512-JZoLKMzgYXzDdpyKdgw+4JG9nKFd/oab8VDTnwd6iY/mHjmuQUx7kFlOMZ5pNdMK/jcY02Ks7oECHC+ZnwLwqw==",
-      "dev": true,
-      "requires": {
-        "aws-sdk": "2.310.0",
-        "sinon": "6.2.0",
-        "traverse": "0.6.6"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -93,16 +37,6 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
-    },
-    "buffer": {
-      "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
-      }
     },
     "chai": {
       "version": "4.1.2",
@@ -184,11 +118,6 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -233,11 +162,6 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
-    "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -260,22 +184,6 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-    },
-    "just-extend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
-      "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
-      "dev": true
-    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -285,12 +193,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
-    },
-    "lolex": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.4.tgz",
-      "integrity": "sha512-Gh6Vffq/piTeHwunLNFR1jFVaqlwK9GMNUxFcsO1cwHyvbRKHwX8UDkxmrDnbcPdHNmpv7z2kxtkkSx5xkNpMw==",
-      "dev": true
     },
     "md5": {
       "version": "2.2.1",
@@ -376,19 +278,6 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "nise": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.4.tgz",
-      "integrity": "sha512-pxE0c9PzgrUTyhfv5p+5eMIdfU2bLEsq8VQEuE0kxM4zP7SujSar7rk9wpI2F7RyyCEvLyj5O7Is3RER5F36Fg==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "just-extend": "3.0.0",
-        "lolex": "2.7.4",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
-      }
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -404,77 +293,11 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        }
-      }
-    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
-    },
-    "punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-      "dev": true
-    },
-    "sax": {
-      "version": "1.2.1",
-      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
-    },
-    "sinon": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.2.0.tgz",
-      "integrity": "sha512-gLFZz5UYvOhYzQ+DBzw/OCkmWaLAHlAyQiE2wxUOmAGVdasP9Yw93E+OwZ0UuhW3ReMu1FKniuNsL6VukvC77w==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "1.0.2",
-        "@sinonjs/formatio": "2.0.0",
-        "@sinonjs/samsam": "2.0.0",
-        "diff": "3.5.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.7.4",
-        "nise": "1.4.4",
-        "supports-color": "5.5.0",
-        "type-detect": "4.0.8"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        }
-      }
     },
     "strip-ansi": {
       "version": "4.0.0",
@@ -494,37 +317,11 @@
         "has-flag": "3.0.0"
       }
     },
-    "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-      "dev": true
-    },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-      "dev": true
-    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
-    },
-    "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "wrappy": {
       "version": "1.0.2",
@@ -537,20 +334,6 @@
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
       "dev": true
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "requires": {
-        "sax": "1.2.1",
-        "xmlbuilder": "9.0.7"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-gateway-caching",
-  "version": "1.1.0",
+  "version": "1.1.1-rc1",
   "description": "A plugin for the serverless framework which helps with configuring caching for API Gateway endpoints.",
   "main": "src/apiGatewayCachingPlugin.js",
   "scripts": {
@@ -18,7 +18,6 @@
   "author": "Diana Ionita",
   "license": "ISC",
   "dependencies": {
-    "aws-sdk": "^2.310.0",
     "lodash.get": "^4.4.2",
     "lodash.isempty": "^4.4.0"
   },
@@ -30,7 +29,6 @@
     "url": "https://github.com/DianaIonita/serverless-api-gateway-caching"
   },
   "devDependencies": {
-    "aws-sdk-mock": "^4.1.0",
     "chai": "^4.1.2",
     "chance": "^1.0.16",
     "mocha": "^5.2.0",

--- a/src/stageCache.js
+++ b/src/stageCache.js
@@ -1,5 +1,4 @@
 const isEmpty = require('lodash.isempty');
-const AWS = require('aws-sdk');
 
 const getRestApiId = async (settings, serverless) => {
   const stackName = serverless.providers.aws.naming.getStackName(settings.stage);
@@ -122,10 +121,6 @@ const updateStageCacheSettings = async (settings, serverless) => {
 
   let restApiId = await getRestApiId(settings, serverless);
 
-  AWS.config.update({
-    region: settings.region,
-  });
-
   let patchOps = createPatchForStage(settings);
 
   let endpointsWithCachingEnabled = settings.endpointSettings.filter(e => e.cachingEnabled);
@@ -137,7 +132,6 @@ const updateStageCacheSettings = async (settings, serverless) => {
     let endpointPatch = createPatchForEndpoint(endpointSettings, serverless);
     patchOps = patchOps.concat(endpointPatch);
   }
-  const apiGateway = new AWS.APIGateway();
   let params = {
     restApiId,
     stageName: settings.stage,
@@ -145,7 +139,7 @@ const updateStageCacheSettings = async (settings, serverless) => {
   }
 
   serverless.cli.log(`[serverless-api-gateway-caching] Updating API Gateway cache settings.`);
-  await apiGateway.updateStage(params).promise();
+  await serverless.providers.aws.request('APIGateway', 'updateStage', params, settings.stage, settings.region);
   serverless.cli.log(`[serverless-api-gateway-caching] Done updating API Gateway cache settings.`);
 }
 

--- a/test/steps/given.js
+++ b/test/steps/given.js
@@ -2,9 +2,6 @@ const APP_ROOT = '../..';
 const Serverless = require(`${APP_ROOT}/test/model/Serverless`);
 const ServerlessFunction = require(`${APP_ROOT}/test/model/ServerlessFunction`);
 const chance = require('chance').Chance();
-const AWS = require('aws-sdk');
-const AWSMock = require('aws-sdk-mock');
-AWSMock.setSDKInstance(AWS);
 
 const a_serverless_instance = (serviceName) => {
   return new Serverless(serviceName);
@@ -12,15 +9,6 @@ const a_serverless_instance = (serviceName) => {
 
 const a_serverless_function = name => {
   return new ServerlessFunction(name);
-}
-
-const api_gateway_update_stage_is_mocked = (record) => {
-  AWSMock.mock('APIGateway', 'updateStage', (params, callback) => {
-    if (record) {
-      record(params);
-    }
-    callback(null, { StatusCode: 200 });
-  });
 }
 
 const a_rest_api_id_for_deployment = async (serverless, settings) => {

--- a/test/steps/given.js
+++ b/test/steps/given.js
@@ -21,6 +21,5 @@ const a_rest_api_id_for_deployment = async (serverless, settings) => {
 module.exports = {
   a_serverless_instance,
   a_serverless_function,
-  api_gateway_update_stage_is_mocked,
   a_rest_api_id_for_deployment
 }

--- a/test/steps/teardown.js
+++ b/test/steps/teardown.js
@@ -1,9 +1,0 @@
-const AWSMock = require('aws-sdk-mock');
-
-const unmock_aws_sdk = function () {
-  AWSMock.restore();
-};
-
-module.exports = {
-  unmock_aws_sdk
-}

--- a/test/updating-stage-cache-settings.js
+++ b/test/updating-stage-cache-settings.js
@@ -1,6 +1,5 @@
 const APP_ROOT = '..';
 const given = require(`${APP_ROOT}/test/steps/given`);
-const teardown = require(`${APP_ROOT}/test/steps/teardown`);
 const ApiGatewayCachingSettings = require(`${APP_ROOT}/src/ApiGatewayCachingSettings`);
 const updateStageCacheSettings = require(`${APP_ROOT}/src/stageCache`);
 const UnauthorizedCacheControlHeaderStrategy = require(`${APP_ROOT}/src/UnauthorizedCacheControlHeaderStrategy`);
@@ -43,10 +42,6 @@ describe('Updating stage cache settings', () => {
     it('should send a single request to AWS SDK to update stage', () => {
       request = requestsToAws.filter(r => r.awsService == apiGatewayService && r.method == updateStageMethod);
       expect(request).to.have.lengthOf(1);
-    });
-
-    after(() => {
-      teardown.unmock_aws_sdk();
     });
 
     describe('the request sent to AWS SDK to update stage', () => {
@@ -97,10 +92,6 @@ describe('Updating stage cache settings', () => {
         await when_updating_stage_cache_settings(settings, serverless);
 
         requestsToAws = serverless.getRequestsToAws();
-      });
-
-      after(() => {
-        teardown.unmock_aws_sdk();
       });
 
       describe('the request sent to AWS SDK to update stage', () => {
@@ -161,10 +152,6 @@ describe('Updating stage cache settings', () => {
         await when_updating_stage_cache_settings(settings, serverless);
 
         requestsToAws = serverless.getRequestsToAws();
-      });
-
-      after(() => {
-        teardown.unmock_aws_sdk();
       });
 
       describe('the request sent to AWS SDK to update stage', () => {
@@ -366,10 +353,6 @@ describe('Updating stage cache settings', () => {
             apiGatewayRequest = requestsToAws.find(r => r.awsService == apiGatewayService && r.method == updateStageMethod);
           });
 
-          after(() => {
-            teardown.unmock_aws_sdk();
-          });
-
           it('should set whether the endpoint requires authorization for cache control', () => {
             expect(apiGatewayRequest.properties.patchOperations).to.deep.include(scenario.expectedPatchForAuth);
           });
@@ -401,10 +384,6 @@ describe('Updating stage cache settings', () => {
 
       requestsToAws = serverless.getRequestsToAws();
       apiGatewayRequest = requestsToAws.find(r => r.awsService == apiGatewayService && r.method == updateStageMethod);
-    });
-
-    after(() => {
-      teardown.unmock_aws_sdk();
     });
 
     it('should enable caching for the GET method', () => {
@@ -452,10 +431,6 @@ describe('Updating stage cache settings', () => {
 
       requestsToAws = serverless.getRequestsToAws();
       apiGatewayRequest = requestsToAws.find(r => r.awsService == apiGatewayService && r.method == updateStageMethod);
-    });
-
-    after(() => {
-      teardown.unmock_aws_sdk();
     });
 
     let allMethods = ['GET', 'DELETE', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT'];


### PR DESCRIPTION
It seems that there's already an `aws` instance provided by `serverless`. It contains the correct credentials and region already, along with other settings a fresh `aws` instance might be missing.