### PR TITLE
add support required for parameters cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,6 @@ functions:
               handleUnauthorizedRequests: Ignore
             cacheKeyParameters:
               - name: request.path.pawId
+                required: false # default is true
               - name: request.header.Accept-Language
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-gateway-caching",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A plugin for the serverless framework which helps with configuring caching for API Gateway endpoints.",
   "main": "src/apiGatewayCachingPlugin.js",
   "scripts": {

--- a/src/pathParametersCache.js
+++ b/src/pathParametersCache.js
@@ -48,9 +48,12 @@ const addPathParametersCacheConfig = (settings, serverless) => {
     }
 
     for (let cacheKeyParameter of endpointSettings.cacheKeyParameters) {
-      method.resource.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = true;
-      method.resource.Properties.Integration.RequestParameters[`integration.${cacheKeyParameter.name}`] = `method.${cacheKeyParameter.name}`;
-      method.resource.Properties.Integration.CacheKeyParameters.push(`method.${cacheKeyParameter.name}`);
+      const { name, required } = cacheKeyParameter;
+      // set default to true, to prevent breaking change. and force to boolean when available.
+      const requiredBool = typeof required !== 'undefined' ? !!required : true;
+      method.resource.Properties.RequestParameters[`method.${name}`] = requiredBool;
+      method.resource.Properties.Integration.RequestParameters[`integration.${name}`] = `method.${name}`;
+      method.resource.Properties.Integration.CacheKeyParameters.push(`method.${name}`);
     }
     method.resource.Properties.Integration.CacheNamespace = `${method.name}CacheNS`;
   }


### PR DESCRIPTION
Added support for required option cacheKeyParameter back in. 
now it always sets the required to true, also for queryParameters. 

```
            cacheKeyParameters:
              - name: request.path.pawId
                required: false # default is true
              - name: request.header.Accept-Language
```
default is set to true to prevent current users from having any settings changed after the update.

i tested it with aws, and works for me without problems.