### PR TITLE
Bug/issue14 - Path parameter cache configuration fix

### DIFF
--- a/src/pathParametersCache.js
+++ b/src/pathParametersCache.js
@@ -28,7 +28,7 @@ const getApiGatewayMethodFor = (functionName, stage, serverless) => {
   const methods = getResourcesByType('AWS::ApiGateway::Method', serverless);
   for (let method of methods) {
     let stringified = JSON.stringify(method);
-    if (stringified.lastIndexOf(lambdaFunctionResource.name) != -1) {
+    if (stringified.lastIndexOf(`"${lambdaFunctionResource.name}"`) != -1) {
       return method;
     }
   }

--- a/test/configuring-path-parameters.js
+++ b/test/configuring-path-parameters.js
@@ -169,6 +169,104 @@ describe('Configuring path parameter caching', () => {
       });
     }
   });
+
+  describe('when there are two endpoints with a cache key parameter', () => {
+    describe(`and the second endpoint's name is a substring of the first endpoint's name`, () => {
+      let method, firstEndpointName, firstEndpointCacheKeyParameters, secondEndpointName, secondEndpointCacheKeyParameters;
+      before(() => {
+        firstEndpointName = 'catpaw';
+        secondEndpointName = 'paw';
+        firstEndpointCacheKeyParameters = [{ name: 'request.path.catPawId' }];
+        secondEndpointCacheKeyParameters = [{ name: 'request.path.pawId' }];
+
+        let firstFunctionWithCaching = given.a_serverless_function(firstEndpointName)
+          .withHttpEndpoint('get', '/cat/paw/{pawId}', { enabled: true, cacheKeyParameters: firstEndpointCacheKeyParameters });
+
+        let secondFunctionWithCaching = given.a_serverless_function(secondEndpointName)
+          .withHttpEndpoint('get', '/paw/{catPawId}', { enabled: true, cacheKeyParameters: secondEndpointCacheKeyParameters });
+
+        serverless = given.a_serverless_instance(serviceName)
+          .withApiGatewayCachingConfig(true, '0.5', 45)
+          .forStage(stage)
+          .withFunction(firstFunctionWithCaching)
+          .withFunction(secondFunctionWithCaching);
+
+        cacheSettings = new ApiGatewayCachingSettings(serverless);
+
+        when_configuring_path_parameters(cacheSettings, serverless);
+      });
+
+      describe('on the method corresponding with the first endpoint with cache key parameters', () => {
+        before(() => {
+          method = serverless.getMethodResourceForFunction(firstEndpointName);
+        });
+
+        it('should configure them as request parameters', () => {
+          for (let parameter of firstEndpointCacheKeyParameters) {
+            expect(method.Properties.RequestParameters)
+              .to.deep.include({
+                [`method.${parameter.name}`]: {}
+              });
+          }
+        });
+
+        it('should set integration request parameters', () => {
+          for (let parameter of firstEndpointCacheKeyParameters) {
+            expect(method.Properties.Integration.RequestParameters)
+              .to.deep.include({
+                [`integration.${parameter.name}`]: `method.${parameter.name}`
+              });
+          }
+        });
+
+        it('should set integration cache key parameters', () => {
+          for (let parameter of firstEndpointCacheKeyParameters) {
+            expect(method.Properties.Integration.CacheKeyParameters)
+              .to.include(`method.${parameter.name}`);
+          }
+        });
+
+        it('should set a cache namespace', () => {
+          expect(method.Properties.Integration.CacheNamespace).to.exist;
+        });
+      });
+
+      describe('on the method corresponding with the second endpoint with cache key parameters', () => {
+        before(() => {
+          method = serverless.getMethodResourceForFunction(secondEndpointName);
+        });
+
+        it('should configure them as request parameters', () => {
+          for (let parameter of secondEndpointCacheKeyParameters) {
+            expect(method.Properties.RequestParameters)
+              .to.deep.include({
+                [`method.${parameter.name}`]: {}
+              });
+          }
+        });
+
+        it('should set integration request parameters', () => {
+          for (let parameter of secondEndpointCacheKeyParameters) {
+            expect(method.Properties.Integration.RequestParameters)
+              .to.deep.include({
+                [`integration.${parameter.name}`]: `method.${parameter.name}`
+              });
+          }
+        });
+
+        it('should set integration cache key parameters', () => {
+          for (let parameter of secondEndpointCacheKeyParameters) {
+            expect(method.Properties.Integration.CacheKeyParameters)
+              .to.include(`method.${parameter.name}`);
+          }
+        });
+
+        it('should set a cache namespace', () => {
+          expect(method.Properties.Integration.CacheNamespace).to.exist;
+        });
+      });
+    });
+  });
 });
 
 const when_configuring_path_parameters = (settings, serverless) => {

--- a/test/model/Serverless.js
+++ b/test/model/Serverless.js
@@ -112,14 +112,14 @@ const addFunctionToCompiledCloudFormationTemplate = (functionName, serverless) =
   let { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
   let functionTemplate = clone(require('./templates/aws-lambda-function'));
   functionTemplate.Properties.FunctionName = fullFunctionName;
-  let functionResourceName = chance.word({ length: 10 });
+  let functionResourceName = `${functionName}LambdaFunction`;
   Resources[functionResourceName] = functionTemplate;
 
   let methodTemplate = clone(require('./templates/aws-api-gateway-method'));
   let stringifiedMethodTemplate = JSON.stringify(methodTemplate);
   stringifiedMethodTemplate = stringifiedMethodTemplate.replace('#{LAMBDA_RESOURCE_DEPENDENCY}', functionResourceName);
   methodTemplate = JSON.parse(stringifiedMethodTemplate);
-  methodResourceName = chance.word({ length: 12 });
+  methodResourceName = `ApiGatewayMethod${functionName}VarGet`;
   Resources[methodResourceName] = methodTemplate
   return { functionResourceName, methodResourceName }
 }


### PR DESCRIPTION
Fixed issue where path parameter cache was not being configured if a serverless function name was a substring of a previous serverless function name, i.e. functions named `catpaw` and `paw`.