### PR TITLE
Fixed the method type matching and the handler type matching

### DIFF
--- a/src/pathParametersCache.js
+++ b/src/pathParametersCache.js
@@ -15,7 +15,8 @@ const getApiGatewayMethodNameFor = (path, httpMethod) => {
   let gatewayResourceName = pathElements
     .map(element => {
       element = element.toLowerCase();
-      element = element.replace('+', '');
+      element = element.split("+").join('');
+      element = element.split(".").join('');
       if (element.startsWith('{')) {
         element = element.substring(element.indexOf('{') + 1, element.indexOf('}')) + "Var";
       }

--- a/src/stageCache.js
+++ b/src/stageCache.js
@@ -67,7 +67,7 @@ const patchForMethod = (path, method, endpointSettings) => {
 const httpEventOf = (lambda, endpointSettings) => {
   return lambda.events.filter(e => e.http != undefined)
                       .filter(e => e.http.path === endpointSettings.path || "/" + e.http.path === endpointSettings.path)
-                      .filter(e => e.http.method === endpointSettings.method);
+                      .filter(e => e.http.method.toUpperCase() === endpointSettings.method.toUpperCase());
 }
 
 const createPatchForEndpoint = (endpointSettings, serverless) => {


### PR DESCRIPTION
The plugin breaks when the method name is in uppercase and if the handler name contains multiple dots.

Here's a snippet from my serverless configuration file that causes the plugin to break.

```yaml
functions:
  minified:
    handler: handler.mininify
    events:
    - http:
        path: polyfill.min.js
        method: GET
        cors:
          origin: '*'
          maxAge: 86400
          allowCredentials: true
```