### PR TITLE
fix: case on method

### DIFF
--- a/src/ApiGatewayCachingSettings.js
+++ b/src/ApiGatewayCachingSettings.js
@@ -45,7 +45,7 @@ class ApiGatewayEndpointCachingSettings {
     this.functionName = functionName;
     
     this.path = event.http.path;
-    this.method = event.http.method;
+    this.method = event.http.method.toLowerCase();
     
     if (!event.http.caching) {
       this.cachingEnabled = false;


### PR DESCRIPTION
When method is set with caps (ie `GET`), which is very common, endpoints don't get overwritten.

Fixes #30 