### PR TITLE
Added support for http events defined in shorthand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-gateway-caching",
-  "version": "1.3.0",
+  "version": "1.3.1-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-gateway-caching",
-  "version": "1.3.0",
+  "version": "1.3.1-rc1",
   "description": "A plugin for the serverless framework which helps with configuring caching for API Gateway endpoints.",
   "main": "src/apiGatewayCachingPlugin.js",
   "scripts": {

--- a/src/ApiGatewayCachingSettings.js
+++ b/src/ApiGatewayCachingSettings.js
@@ -19,7 +19,7 @@ const mapUnauthorizedRequestStrategy = strategy => {
 }
 
 const isApiGatewayEndpoint = event => {
-  return event.http ?  true: false;
+  return event.http ? true : false;
 }
 
 class PerKeyInvalidationSettings {
@@ -43,10 +43,17 @@ class ApiGatewayEndpointCachingSettings {
   constructor(customFunctionName, functionName, event, globalSettings) {
     this.customFunctionName = customFunctionName;
     this.functionName = functionName;
-    
-    this.path = event.http.path;
-    this.method = event.http.method;
-    
+
+    if (typeof (event.http) === 'string') {
+      let parts = event.http.split(' ');
+      this.method = parts[0];
+      this.path = parts[1];
+    }
+    else {
+      this.path = event.http.path;
+      this.method = event.http.method;
+    }
+
     if (!event.http.caching) {
       this.cachingEnabled = false;
       return;
@@ -56,7 +63,7 @@ class ApiGatewayEndpointCachingSettings {
     this.dataEncrypted = cachingConfig.dataEncrypted || globalSettings.dataEncrypted;
     this.cacheTtlInSeconds = cachingConfig.ttlInSeconds || globalSettings.cacheTtlInSeconds;
     this.cacheKeyParameters = cachingConfig.cacheKeyParameters;
-    
+
     if (!cachingConfig.perKeyInvalidation) {
       this.perKeyInvalidation = globalSettings.perKeyInvalidation;
     } else {
@@ -90,7 +97,7 @@ class ApiGatewayCachingSettings {
 
     for (let functionName in serverless.service.functions) {
       let functionSettings = serverless.service.functions[functionName];
-      for(let event in functionSettings.events) {
+      for (let event in functionSettings.events) {
         if (isApiGatewayEndpoint(functionSettings.events[event])) {
           this.endpointSettings.push(new ApiGatewayEndpointCachingSettings(functionSettings.name, functionName, functionSettings.events[event], this))
         }

--- a/src/stageCache.js
+++ b/src/stageCache.js
@@ -70,9 +70,24 @@ const patchForMethod = (path, method, endpointSettings) => {
 }
 
 const httpEventOf = (lambda, endpointSettings) => {
-  return lambda.events.filter(e => e.http != undefined)
-    .filter(e => e.http.path === endpointSettings.path || "/" + e.http.path === endpointSettings.path)
-    .filter(e => e.http.method.toUpperCase() === endpointSettings.method.toUpperCase());
+  let httpEvents = lambda.events.filter(e => e.http != undefined)
+    .map(e => {
+      if (typeof (e.http) === 'string') {
+        let parts = e.http.split(' ');
+        return {
+          method: parts[0],
+          path: parts[1]
+        }
+      } else {
+        return {
+          method: e.http.method,
+          path: e.http.path
+        }
+      }
+    });
+
+  return httpEvents.filter(e => e.path = endpointSettings.path || "/" + e.path === endpointSettings.path)
+    .filter(e => e.method.toUpperCase() == endpointSettings.method.toUpperCase());
 }
 
 const createPatchForEndpoint = (endpointSettings, serverless) => {
@@ -86,7 +101,7 @@ const createPatchForEndpoint = (endpointSettings, serverless) => {
     serverless.cli.log(`[serverless-api-gateway-caching] Lambda ${endpointSettings.functionName} has not defined any HTTP events.`);
     return;
   }
-  let { path, method } = httpEvents[0].http;
+  let { path, method } = httpEvents[0];
 
   let patch = [];
   if (method.toUpperCase() == 'ANY') {

--- a/test/creating-settings.js
+++ b/test/creating-settings.js
@@ -511,6 +511,32 @@ describe('Creating settings', () => {
       });
     });
   });
+
+  describe('when a http endpoint is defined in shorthand', () => {
+    describe(`and caching is turned on globally`, () => {
+      before(() => {
+        endpoint = given.a_serverless_function('list-cats')
+          .withHttpEndpointInShorthand('get /cats');
+        serverless = given.a_serverless_instance()
+          .withApiGatewayCachingConfig(true)
+          .withFunction(endpoint);
+
+        cacheSettings = createSettingsFor(serverless);
+      });
+
+      it('settings should contain the endpoint method', () => {
+        expect(cacheSettings.endpointSettings[0].method).to.equal('get');
+      });
+
+      it('settings should contain the endpoint path', () => {
+        expect(cacheSettings.endpointSettings[0].path).to.equal('/cats');
+      });
+
+      it('caching should not be enabled for the http endpoint', () => {
+        expect(cacheSettings.endpointSettings[0].cachingEnabled).to.be.false;
+      });
+    });
+  });
 });
 
 const createSettingsFor = (serverless, options) => {

--- a/test/model/Serverless.js
+++ b/test/model/Serverless.js
@@ -159,8 +159,17 @@ const addFunctionToCompiledCloudFormationTemplate = (serverlessFunction, serverl
     methodResourceName = `ApiGatewayMethod${functionName}VarGet`;
   } else {
     for (event of events) {
-      const path = event.http.path;
-      const method = event.http.method;
+      // if event is defined in shorthand
+      let path, method;
+      if (typeof (event.http) === 'string') {
+        let parts = event.http.split(' ');
+        method = parts[0];
+        path = parts[1];
+      }
+      else {
+        path = event.http.path;
+        method = event.http.method;
+      }
       methodResourceName = createMethodResourceNameFor(path, method);
       Resources[methodResourceName] = methodTemplate;
     }

--- a/test/model/ServerlessFunction.js
+++ b/test/model/ServerlessFunction.js
@@ -21,6 +21,16 @@ class ServerlessFunction {
 
     return this;
   }
+
+  withHttpEndpointInShorthand(shorthand) {
+    let f = this.getFunction();
+    if (!f.events) { f.events = []; }
+    f.events.push({
+      http: shorthand
+    });
+
+    return this;
+  }
 }
 
 module.exports = ServerlessFunction;


### PR DESCRIPTION
Caching is by default disabled for functions which don't specify `caching: enabled` in their endpoint settings, therefore functions defined in shorthand have caching disabled.