### PR TITLE
Fixed issue where two-step deployment process failed because settings were not initialised

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-gateway-caching",
-  "version": "1.3.2",
+  "version": "1.3.3-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -118,6 +118,16 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "1.0.1",
+        "merge-descriptors": "1.0.1"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -184,6 +194,12 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -209,6 +225,12 @@
         "crypt": "0.0.2",
         "is-buffer": "1.1.6"
       }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -277,6 +299,12 @@
         }
       }
     },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -298,11 +326,37 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
+    },
+    "proxyquire": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
+      "integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "1.0.2",
+        "module-not-found-error": "1.0.1",
+        "resolve": "1.8.1"
+      }
+    },
+    "resolve": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.6"
+      }
     },
     "strip-ansi": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-gateway-caching",
-  "version": "1.3.2",
+  "version": "1.3.3-rc2",
   "description": "A plugin for the serverless framework which helps with configuring caching for API Gateway endpoints.",
   "main": "src/apiGatewayCachingPlugin.js",
   "scripts": {
@@ -33,6 +33,7 @@
     "chai": "^4.1.2",
     "chance": "^1.0.16",
     "mocha": "^5.2.0",
-    "mocha-junit-reporter": "^1.18.0"
+    "mocha-junit-reporter": "^1.18.0",
+    "proxyquire": "^2.1.0"
   }
 }

--- a/src/apiGatewayCachingPlugin.js
+++ b/src/apiGatewayCachingPlugin.js
@@ -44,6 +44,11 @@ class ApiGatewayCachingPlugin {
       this.serverless.cli.log(`[serverless-api-gateway-caching] No Rest API found. Caching settings will not be updated.`);
       return;
     }
+
+    if (!this.settings) {
+      this.createSettings()
+    }
+
     return updateStageCacheSettings(this.settings, this.serverless);
   }
 }

--- a/test/creating-plugin.js
+++ b/test/creating-plugin.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const chai = require('chai');
+const proxyquire = require('proxyquire');
+const expect = chai.expect;
+
+describe('Creating plugin', () => {
+  describe('When updating the CloudFormation template', () => {
+    let scenarios = [
+      {
+        description: 'there is no rest api',
+        thereIsARestApi: false,
+        expectedLogMessage: '[serverless-api-gateway-caching] No Rest API found. Caching settings will not be updated.',
+        expectedToOutputRestApiId: false,
+        expectedToAddPathParametersCacheConfig: false
+      },
+      {
+        description: 'there is a rest api and caching is enabled',
+        cachingEnabled: true,
+        thereIsARestApi: true,
+        expectedLogMessage: undefined,
+        expectedToOutputRestApiId: true,
+        expectedToAddPathParametersCacheConfig: true,
+      },
+      {
+        description: 'there is a rest api and caching is disabled',
+        cachingEnabled: false,
+        thereIsARestApi: true,
+        expectedLogMessage: undefined,
+        expectedToOutputRestApiId: true,
+        expectedToAddPathParametersCacheConfig: false,
+      }
+    ];
+
+    for (let scenario of scenarios) {
+      describe(`and ${scenario.description}`, () => {
+        let logCalledWith, outputRestApiIdCalled = false, addPathParametersCacheConfigCalled = false;
+        const serverless = { cli: { log: (message) => { logCalledWith = message } } };
+        const restApiIdStub = {
+          restApiExists: () => scenario.thereIsARestApi,
+          outputRestApiIdTo: () => outputRestApiIdCalled = true
+        };
+        const pathParametersCacheStub = {
+          addPathParametersCacheConfig: () => addPathParametersCacheConfigCalled = true
+        }
+        const ApiGatewayCachingPlugin = proxyquire('../src/apiGatewayCachingPlugin', { './restApiId': restApiIdStub, './pathParametersCache': pathParametersCacheStub });
+
+        before(() => {
+          const plugin = new ApiGatewayCachingPlugin(serverless, {});
+          plugin.settings = { cachingEnabled: scenario.cachingEnabled }
+          plugin.updateCloudFormationTemplate();
+        });
+
+        it('should log a message', () => {
+          expect(logCalledWith).to.equal(scenario.expectedLogMessage);
+        });
+
+        it(`is expected to output rest api id: ${scenario.expectedToOutputRestApiId}`, () => {
+          expect(outputRestApiIdCalled).to.equal(scenario.expectedToOutputRestApiId);
+        });
+
+        it(`is expected to add path parameters to cache config: ${scenario.expectedToAddPathParametersCacheConfig}`, () => {
+          expect(addPathParametersCacheConfigCalled).to.equal(scenario.expectedToAddPathParametersCacheConfig);
+        });
+      });
+    }
+  });
+
+  describe('When updating the stage', () => {
+    let scenarios = [
+      {
+        description: 'there is no rest api',
+        thereIsARestApi: false,
+        expectedLogMessage: '[serverless-api-gateway-caching] No Rest API found. Caching settings will not be updated.',
+        expectedToUpdateStageCache: false,
+        expectedToHaveSettings: false
+      },
+      {
+        description: 'there is a rest api',
+        thereIsARestApi: true,
+        expectedLogMessage: undefined,
+        expectedToUpdateStageCache: true,
+        expectedToHaveSettings: true
+      }
+    ];
+
+    for (let scenario of scenarios) {
+      describe(`and ${scenario.description}`, () => {
+        let logCalledWith, updateStageCacheSettingsCalled = false;
+        const serverless = { cli: { log: (message) => { logCalledWith = message } } };
+        const restApiIdStub = {
+          restApiExists: () => scenario.thereIsARestApi,
+          outputRestApiIdTo: () => outputRestApiIdCalled = true
+        };
+        const stageCacheStub = () => updateStageCacheSettingsCalled = true;
+        const ApiGatewayCachingPlugin = proxyquire('../src/apiGatewayCachingPlugin', { './restApiId': restApiIdStub, './stageCache': stageCacheStub });
+        const plugin = new ApiGatewayCachingPlugin(serverless, {});
+
+        before(() => {
+          plugin.updateStage();
+        });
+
+        it('should log a message', () => {
+          expect(logCalledWith).to.equal(scenario.expectedLogMessage);
+        });
+
+        it(`is expected to have settings: ${scenario.expectedToHaveSettings}`, () => {
+          if (scenario.expectedToHaveSettings) {
+            expect(plugin.settings).to.exist;
+          } else {
+            expect(plugin.settings).to.not.exist;
+          }
+        });
+
+        it(`is expected to update stage cache: ${scenario.expectedToUpdateStageCache}`, () => {
+          expect(updateStageCacheSettingsCalled).to.equal(scenario.expectedToUpdateStageCache);
+        });
+      });
+    }
+  });
+});


### PR DESCRIPTION
Hey @triqi - this is the PR where I'm using `proxyquire` to stub dependencies without injecting them as parameters.