### PR TITLE
Set encryption on stage

### DIFF
--- a/src/stageCache.js
+++ b/src/stageCache.js
@@ -29,6 +29,11 @@ const createPatchForStage = (settings) => {
       path: '/cacheClusterSize',
       value: `${settings.cacheClusterSize}`
     });
+    patch.push({
+      op: 'replace',
+      path: '/*/*/caching/dataEncrypted',
+      value: `${settings.dataEncrypted}`
+    });
   }
   return patch;
 }

--- a/test/model/Serverless.js
+++ b/test/model/Serverless.js
@@ -33,12 +33,13 @@ class Serverless {
     return this;
   }
 
-  withApiGatewayCachingConfig(cachingEnabled, clusterSize, ttlInSeconds, perKeyInvalidation) {
+  withApiGatewayCachingConfig(cachingEnabled, clusterSize, ttlInSeconds, perKeyInvalidation, dataEncrypted) {
     this.service.custom.apiGatewayCaching = {
       enabled: cachingEnabled,
       clusterSize,
       ttlInSeconds,
-      perKeyInvalidation
+      perKeyInvalidation,
+      dataEncrypted
     };
     return this;
   }

--- a/test/updating-stage-cache-settings.js
+++ b/test/updating-stage-cache-settings.js
@@ -107,8 +107,8 @@ describe('Updating stage cache settings', () => {
           expect(apiGatewayRequest.properties.stageName).to.equal('somestage');
         });
 
-        it('should specify exactly two patch operations', () => {
-          expect(apiGatewayRequest.properties.patchOperations).to.have.lengthOf(2);
+        it('should specify exactly three patch operations', () => {
+          expect(apiGatewayRequest.properties.patchOperations).to.have.lengthOf(3);
         })
 
         it('should enable caching', () => {
@@ -124,6 +124,14 @@ describe('Updating stage cache settings', () => {
             op: 'replace',
             path: '/cacheClusterSize',
             value: '0.5'
+          });
+        });
+
+        it('should set the cache encryption', () => {
+          expect(apiGatewayRequest.properties.patchOperations).to.deep.include({
+            op: 'replace',
+            path: '/*/*/caching/dataEncrypted',
+            value: 'false'
           });
         });
 


### PR DESCRIPTION
Hi thanks for this great plugin! We need to have encryption enabled full stop, and I noticed it wasn't picking up this config in my serverless.yml:

```yaml
custom:
    apiGatewayCaching:
      enabled: true
      dataEncrypted: true # default is false
```

This change does the trick, and is working well for us now. How does this PR look to you?