### PR TITLE
AWS_Proxy type does not allow integration object to specify RequestPa…

### DIFF
--- a/src/pathParametersCache.js
+++ b/src/pathParametersCache.js
@@ -52,7 +52,9 @@ const addPathParametersCacheConfig = (settings, serverless) => {
     for (let cacheKeyParameter of endpointSettings.cacheKeyParameters) {
       let existingValue = method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`];
       method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = (existingValue == null || existingValue == undefined) ? {} : existingValue;
-      method.Properties.Integration.RequestParameters[`integration.${cacheKeyParameter.name}`] = `method.${cacheKeyParameter.name}`;
+      If ( method.Properties.Type !==  'AWS_PROXY') {
+        method.Properties.Integration.RequestParameters[`integration.${cacheKeyParameter.name}`] = `method.${cacheKeyParameter.name}`;
+      }
       method.Properties.Integration.CacheKeyParameters.push(`method.${cacheKeyParameter.name}`);
     }
     method.Properties.Integration.CacheNamespace = `${resourceName}CacheNS`;


### PR DESCRIPTION
…rameters

Hi Jonathan,

Mariam here from AWS Premium Support with a follow up to our call earlier. 

During our chat, I confirmed with you that an API Gateway with a proxy integration (AWS Proxy or HTTP proxy) does not give you the option to set request parameters for the method's Integration Request as the full HTTP request is passed through to the backend.

You pointed me in the direction of this document [1] which states that in the value set for "CacheKeyParameters" must be set as a request parameter. 

However in the meantime, I will be in touch with the internal API Gateway experts with regards to the documentation and get back to you tomorrow with our findings and some official wording.

Please do let me know if you have any additional questions. In the meantime, I will give you a call tomorrow at about 12pm UTC. Could you please confirm that +18023234558 is the best number to reach you on and I will be in touch.

Have a great day and chat soon.


[1] https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-integration-settings-integration-request.html 
  
  
  


Best regards,

Mariam N.
Amazon Web Services