### PR TITLE
Add multiple caching keys (method.response.body and others)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ Specifying where the request parameters can be found:
 - request.header.PARAM_NAME
 - request.multivalueheader.PARAM_NAME
 
-## Limitations
-I don't currently know of a way to define cache key parameters based on the `request.body` or `request.body.JSONPath_EXPRESSION`, which should theoretically be possible according to [AWS Documentation on request parameter mapping](https://docs.aws.amazon.com/apigateway/latest/developerguide/request-response-data-mappings.html). See [this issue](https://github.com/DianaIonita/serverless-api-gateway-caching/issues/63) for details.
-
 ## Examples
 
 ### Minimal setup
@@ -62,6 +59,21 @@ functions:
       - http:
           path: /cat
           method: post
+  
+  # Responses are cached based on the 'pawId' path parameter and authorizer sub.
+  get-cat-by-paw-id:
+    handler: rest_api/cat/get/handler.handle
+    events:
+      - http:
+          path: /cats/{pawId}
+          method: get
+          caching:
+            enabled: true
+            cacheKeyParameters:
+              - name: integration.request.path.pawId
+                value: method.request.path.pawId
+              - name: integration.request.header.authorizerSubCache
+                value: context.authorizer.claims.sub
 
   # Responses are cached based on the 'pawId' path parameter and the 'Accept-Language' header
   get-cat-by-paw-id:
@@ -73,8 +85,10 @@ functions:
           caching:
             enabled: true
             cacheKeyParameters:
-              - name: request.path.pawId
-              - name: request.header.Accept-Language
+              - name: integration.request.path.pawId
+                value: method.request.path.pawId
+              - name: integration.request.header.Accept-Language
+                value: method.request.header.Accept-Language
 
   # Responses are cached based on the 'breed' query string parameter and the 'Accept-Language' header
   get-cats-by-breed:
@@ -86,8 +100,10 @@ functions:
           caching:
             enabled: true
             cacheKeyParameters:
-              - name: request.querystring.breed
-              - name: request.header.Accept-Language
+              - name: integration.request.querystring.breed
+                value: method.request.querystring.breed
+              - name: integration.request.header.Accept-Language
+                value: method.request.querystring.breed
 ```
 
 ### Configuring the cache cluster size and cache time to live
@@ -137,8 +153,10 @@ functions:
               requireAuthorization: true # default is true
               handleUnauthorizedRequests: Fail # default is "IgnoreWithWarning"
             cacheKeyParameters:
-              - name: request.path.pawId
-              - name: request.header.Accept-Language
+              - name: integration.request.path.pawId
+                value: method.request.path.pawId
+              - name: integration.request.header.Accept-Language
+                value: method.request.header.Accept-Language
 ```
 
 

--- a/src/pathParametersCache.js
+++ b/src/pathParametersCache.js
@@ -32,7 +32,7 @@ const getApiGatewayMethodNameFor = (path, httpMethod) => {
 
 const addPathParametersCacheConfig = (settings, serverless) => {
   for (let endpointSettings of settings.endpointSettings) {
-    if (!endpointSettings.cacheKeyParameters) {
+    if (!endpointSettings.cacheKeyParameters || !endpointSettings.cachingEnabled) {
       continue;
     }
     const resourceName = getApiGatewayMethodNameFor(endpointSettings.path, endpointSettings.method);

--- a/src/pathParametersCache.js
+++ b/src/pathParametersCache.js
@@ -50,14 +50,20 @@ const addPathParametersCacheConfig = (settings, serverless) => {
     }
 
     for (let cacheKeyParameter of endpointSettings.cacheKeyParameters) {
-      let existingValue = method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`];
-      method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = (existingValue == null || existingValue == undefined) ? {} : existingValue;
-
-      if (method.Properties.Integration.Type !== 'AWS_PROXY') {
-        method.Properties.Integration.RequestParameters[`integration.${cacheKeyParameter.name}`] = `method.${cacheKeyParameter.name}`;
+      let existingValue = method.Properties.RequestParameters[`${cacheKeyParameter.name}`];
+      if (
+        cacheKeyParameter.value.includes('method.request.querystring') ||
+        cacheKeyParameter.value.includes('method.request.header') ||
+        cacheKeyParameter.value.includes('method.request.path')
+      ) {
+        method.Properties.RequestParameters[`${cacheKeyParameter.value}`] = (existingValue == null || existingValue == undefined) ? {} : existingValue;
       }
 
-      method.Properties.Integration.CacheKeyParameters.push(`method.${cacheKeyParameter.name}`);
+      if (method.Properties.Integration.Type !== 'AWS_PROXY') {
+        method.Properties.Integration.RequestParameters[`${cacheKeyParameter.name}`] = `${cacheKeyParameter.value}`;
+      }
+
+      method.Properties.Integration.CacheKeyParameters.push(`${cacheKeyParameter.name}`);
     }
     method.Properties.Integration.CacheNamespace = `${resourceName}CacheNS`;
   }


### PR DESCRIPTION
Hi!
The limitations of the cache keys are produced by this piece of code:
```javascript
for (let cacheKeyParameter of endpointSettings.cacheKeyParameters) {
      let existingValue = method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`];
      method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = (existingValue == null || existingValue == undefined) ? {} : existingValue;

      if (method.Properties.Integration.Type !== 'AWS_PROXY') {
        method.Properties.Integration.RequestParameters[`integration.${cacheKeyParameter.name}`] = `method.${cacheKeyParameter.name}`;
      }

      method.Properties.Integration.CacheKeyParameters.push(`method.${cacheKeyParameter.name}`);
}
```

In resources of type AWS::ApiGateWay::Method we have two places to define the request parameters.
- In the request parameters of the root we can only define 3 types of parameters: path, querystring and header. Any other produces an error.
- Once the parameters of these 3 types have been defined to be able to use them within Integration we can use any of the keys that appear in the AWS documentation. Parameters of the authorizer or body included as shown below.
![image](https://user-images.githubusercontent.com/16381759/70262712-20700680-1795-11ea-8e95-47fd222cb5ae.png)

Example:
![image](https://user-images.githubusercontent.com/16381759/70263104-e6ebcb00-1795-11ea-80d7-6d1856feffda.png)



Generate...

![image](https://user-images.githubusercontent.com/16381759/70263362-709b9880-1796-11ea-9a90-d1d5c6459772.png)

As we can see, only the id is generated in the request parameters of the root. Anything else would generate an error.
![image](https://user-images.githubusercontent.com/16381759/70263537-e7389600-1796-11ea-819e-e924945a37f9.png)

Note: As you can see to be able to use fields outside of path, querystring and header as keys we have to put them into some of those three, in this case they were entered as header fields. This should not affect the operation in any case.
