### PR TITLE
added support for cache keys from header mappings, (e.g. method.request.body)

### DIFF
--- a/src/pathParametersCache.js
+++ b/src/pathParametersCache.js
@@ -50,14 +50,29 @@ const addPathParametersCacheConfig = (settings, serverless) => {
     }
 
     for (let cacheKeyParameter of endpointSettings.cacheKeyParameters) {
-      let existingValue = method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`];
-      method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = (existingValue == null || existingValue == undefined) ? {} : existingValue;
+      if (!cacheKeyParameter.value) {
+        let existingValue = method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`];
+        method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = (existingValue == null || existingValue == undefined) ? {} : existingValue;
 
-      if (method.Properties.Integration.Type !== 'AWS_PROXY') {
-        method.Properties.Integration.RequestParameters[`integration.${cacheKeyParameter.name}`] = `method.${cacheKeyParameter.name}`;
+        if (method.Properties.Integration.Type !== 'AWS_PROXY') {
+          method.Properties.Integration.RequestParameters[`integration.${cacheKeyParameter.name}`] = `method.${cacheKeyParameter.name}`;
+        }
+
+        method.Properties.Integration.CacheKeyParameters.push(`method.${cacheKeyParameter.name}`);
+      } else {
+        let existingValue = method.Properties.RequestParameters[cacheKeyParameter.value];
+        if (
+          cacheKeyParameter.value.includes('method.request.querystring') ||
+          cacheKeyParameter.value.includes('method.request.header') ||
+          cacheKeyParameter.value.includes('method.request.path')
+        ) {
+          method.Properties.RequestParameters[cacheKeyParameter.value] = (existingValue == null || existingValue == undefined) ? {} : existingValue;
+        }
+        if (method.Properties.Integration.Type !== 'AWS_PROXY') {
+          method.Properties.Integration.RequestParameters[cacheKeyParameter.name] = cacheKeyParameter.value;
+        }
+        method.Properties.Integration.CacheKeyParameters.push(cacheKeyParameter.name)
       }
-
-      method.Properties.Integration.CacheKeyParameters.push(`method.${cacheKeyParameter.name}`);
     }
     method.Properties.Integration.CacheNamespace = `${resourceName}CacheNS`;
   }

--- a/test/configuring-path-parameters.js
+++ b/test/configuring-path-parameters.js
@@ -533,6 +533,108 @@ describe('Configuring path parameter caching', () => {
       });
     });
   }
+
+  describe('when there are methods with mapped cache key parameters', () => {
+    let method, functionWithCachingName, getMethodCacheKeyParameters, postMethodCacheKeyParameters;
+    before(() => {
+      functionWithCachingName = 'cats-graphql';
+      getMethodCacheKeyParameters = [{ name: 'integration.request.header.querystringCacheHeader', value: 'method.request.querystring.query' }];
+      postMethodCacheKeyParameters = [{ name: 'integration.request.header.bodyCacheHeader', value: 'method.request.body' }];
+
+      let functionWithCaching = given.a_serverless_function(functionWithCachingName)
+        .withHttpEndpoint('get', '/graphql', { enabled: true, cacheKeyParameters: getMethodCacheKeyParameters })
+        .withHttpEndpoint('post', '/graphql', { enabled: true, cacheKeyParameters: postMethodCacheKeyParameters });
+
+      serverless = given.a_serverless_instance(serviceName)
+        .withApiGatewayCachingConfig(true, '0.5', 45)
+        .forStage(stage)
+        .withFunction(functionWithCaching);
+
+      when_configuring_path_parameters(serverless)
+    });
+
+    describe('on the GET method', () => {
+      before(() => {
+        method = serverless.getMethodResourceForMethodName("ApiGatewayMethodGraphqlGet");
+      });
+
+      it('should configure appropriate cache key parameters as request parameters', () => {
+        for (let parameter of getMethodCacheKeyParameters) {
+          if (
+            parameter.value.includes('method.request.querystring') ||
+            parameter.value.includes('method.request.header') ||
+            parameter.value.includes('method.request.path')
+          ) {
+            expect(method.Properties.RequestParameters)
+              .to.deep.include({
+                [parameter.value]: {}
+              });
+          }
+        }
+      });
+
+      it('should set integration request parameters', () => {
+        for (let parameter of getMethodCacheKeyParameters) {
+          expect(method.Properties.Integration.RequestParameters)
+            .to.deep.include({
+              [parameter.name]: parameter.value
+            });
+        }
+      });
+
+      it('should set integration cache key parameters', () => {
+        for (let parameter of getMethodCacheKeyParameters) {
+          expect(method.Properties.Integration.CacheKeyParameters)
+            .to.include(parameter.name);
+        }
+      });
+
+      it('should set a cache namespace', () => {
+        expect(method.Properties.Integration.CacheNamespace).to.exist;
+      });
+    });
+
+    describe('on the POST method', () => {
+      before(() => {
+        method = serverless.getMethodResourceForMethodName("ApiGatewayMethodGraphqlPost");
+      });
+
+      it('should configure appropriate cache key parameters as request parameters', () => {
+        for (let parameter of postMethodCacheKeyParameters) {
+          if (
+            parameter.value.includes('method.request.querystring') ||
+            parameter.value.includes('method.request.header') ||
+            parameter.value.includes('method.request.path')
+          ) {
+            expect(method.Properties.RequestParameters)
+              .to.deep.include({
+                [parameter.value]: {}
+              });
+          }
+        }
+      });
+
+      it('should set integration request parameters', () => {
+        for (let parameter of postMethodCacheKeyParameters) {
+          expect(method.Properties.Integration.RequestParameters)
+            .to.deep.include({
+              [parameter.name]: parameter.value
+            });
+        }
+      });
+
+      it('should set integration cache key parameters', () => {
+        for (let parameter of postMethodCacheKeyParameters) {
+          expect(method.Properties.Integration.CacheKeyParameters)
+            .to.include(parameter.name);
+        }
+      });
+
+      it('should set a cache namespace', () => {
+        expect(method.Properties.Integration.CacheNamespace).to.exist;
+      });
+    });
+  })
 });
 
 const when_configuring_path_parameters = (serverless) => {


### PR DESCRIPTION
HI @DianaIonita!

Similar to PR https://github.com/DianaIonita/serverless-api-gateway-caching/pull/65, I needed a way to configure API Gateway to cache responses from my GraphQL Lambda function using `method.request.body` as a cache key.

In order to prevent breaking changes, my solution was to branch off of the existing code if the `cacheKeyParameter` includes a `value` property, which indicates the cache key is from a mapped HTTP header. This new functionality also opens up the possibility of using other values like `context.VARIABLE_NAME` in mapping expressions as well.

I have updated the README and added additional tests to document this new functionality.

With the following configuration, I was able to achieve my desired configuration for a sample `/graphql` endpoint:

```yaml
cats-graphql:
    handler: graphql/handler.handle
    events:
      - http:
          path: /graphql
          method: get
          caching:
            enabled: true
            cacheKeyParameters:
              - name: request.querystring.query
      - http:
          path: /graphql
          method: post
          integration: lambda
          caching:
            enabled: true
            cacheKeyParameters:
              - name: integration.request.header.bodyCacheHeader
                value: method.request.body
```

**GET**
![image](https://user-images.githubusercontent.com/2754894/91897257-a0ad9480-ec5f-11ea-8645-6da40d1b50c9.png)

**POST**
![image](https://user-images.githubusercontent.com/2754894/91897045-54625480-ec5f-11ea-89c2-fc06c0870307.png)



