### PR TITLE
zero in Cache time-to-live (TTL)

### DIFF
--- a/src/ApiGatewayCachingSettings.js
+++ b/src/ApiGatewayCachingSettings.js
@@ -106,7 +106,7 @@ class ApiGatewayCachingSettings {
     this.additionalEndpointSettings = [];
 
     this.cacheClusterSize = cachingSettings.clusterSize || DEFAULT_CACHE_CLUSTER_SIZE;
-    this.cacheTtlInSeconds = cachingSettings.ttlInSeconds || DEFAULT_TTL;
+    this.cacheTtlInSeconds = cachingSettings.ttlInSeconds >= 0 ? cachingSettings.ttlInSeconds: DEFAULT_TTL;
     this.dataEncrypted = cachingSettings.dataEncrypted || DEFAULT_DATA_ENCRYPTED;
 
     const additionalEndpoints = cachingSettings.additionalEndpoints || [];


### PR DESCRIPTION
This line  `this.cacheTtlInSeconds = cachingSettings.ttlInSeconds || DEFAULT_TTL;`  in ApiGatewayCachingSettings.js , Don't allows setup ttlInSeconds in zero seconds and bug detected it allows setup cacheTtlInSeconds less than zero seconds.

The fix is change OR operator validation by ternary operator, like this:
`this.cacheTtlInSeconds = cachingSettings.ttlInSeconds >= 0 ? cachingSettings.ttlInSeconds: DEFAULT_TTL;`
