### PR TITLE
allowed for 0 seconds cache time TTL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 
 # Serverless directories
 .serverless
+
+.idea

--- a/serverless-api-gateway-caching.iml
+++ b/serverless-api-gateway-caching.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/ApiGatewayCachingSettings.js
+++ b/src/ApiGatewayCachingSettings.js
@@ -64,7 +64,7 @@ class ApiGatewayEndpointCachingSettings {
     let cachingConfig = event.http.caching;
     this.cachingEnabled = globalSettings.cachingEnabled ? cachingConfig.enabled : false;
     this.dataEncrypted = cachingConfig.dataEncrypted || globalSettings.dataEncrypted;
-    this.cacheTtlInSeconds = cachingConfig.ttlInSeconds || globalSettings.cacheTtlInSeconds;
+    this.cacheTtlInSeconds = cachingConfig.ttlInSeconds >= 0 ? cachingConfig.ttlInSeconds : globalSettings.cacheTtlInSeconds;
     this.cacheKeyParameters = cachingConfig.cacheKeyParameters;
 
     if (!cachingConfig.perKeyInvalidation) {
@@ -80,7 +80,7 @@ class ApiGatewayAdditionalEndpointCachingSettings {
     this.method = method;
     this.path = path;
     this.cachingEnabled = globalSettings.cachingEnabled ? get(caching, 'enabled', false) : false;
-    this.cacheTtlInSeconds = get(caching, 'ttlInSeconds', globalSettings.cacheTtlInSeconds);
+    this.cacheTtlInSeconds = get(caching, 'ttlInSeconds', undefined) >= 0 ? caching.ttlInSeconds : globalSettings.cacheTtlInSeconds;
     this.dataEncrypted = get(caching, 'dataEncrypted', globalSettings.dataEncrypted);
   }
 }
@@ -106,7 +106,7 @@ class ApiGatewayCachingSettings {
     this.additionalEndpointSettings = [];
 
     this.cacheClusterSize = cachingSettings.clusterSize || DEFAULT_CACHE_CLUSTER_SIZE;
-    this.cacheTtlInSeconds = cachingSettings.ttlInSeconds || DEFAULT_TTL;
+    this.cacheTtlInSeconds = cachingSettings.ttlInSeconds >= 0 ? cachingSettings.ttlInSeconds : DEFAULT_TTL;
     this.dataEncrypted = cachingSettings.dataEncrypted || DEFAULT_DATA_ENCRYPTED;
 
     const additionalEndpoints = cachingSettings.additionalEndpoints || [];


### PR DESCRIPTION
I discovered that we can't set 0 for TTL so I adjusted `ApiGatewayCachingSettings.js` to allow for this.  In some cases, we want to enable caching for only a few endpoints in the Stage.  So, the main Stage caching is set to `true` with TTL 0 and other endpoints you want to cache can be set to a different TTL.