### PR TITLE
Cache key parameters from body don't require lambda integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,6 @@ functions:
       - http:
           path: /graphql
           method: post
-          integration: lambda # you must use lambda integration (instead of the default proxy integration) for this to work
           caching:
             enabled: true
             cacheKeyParameters:
@@ -253,7 +252,6 @@ functions:
       - http:
           path: /graphql
           method: post
-          integration: lambda # you must use lambda integration (instead of the default proxy integration) for this to work
           caching:
             enabled: true
             cacheKeyParameters:
@@ -442,7 +440,6 @@ functions:
       - http:
           path: /cats
           method: post
-          integration: lambda # you must use lambda integration for this to work
           caching:
             enabled: true
             cacheKeyParameters:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-gateway-caching",
-  "version": "1.7.5",
+  "version": "1.8.0-rc1",
   "description": "A plugin for the serverless framework which helps with configuring caching for API Gateway endpoints.",
   "main": "src/apiGatewayCachingPlugin.js",
   "scripts": {

--- a/src/pathParametersCache.js
+++ b/src/pathParametersCache.js
@@ -30,9 +30,12 @@ const addPathParametersCacheConfig = (settings, serverless) => {
         let existingValue = method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`];
         method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = (existingValue == null || existingValue == undefined) ? {} : existingValue;
 
-        if (method.Properties.Integration.Type !== 'AWS_PROXY') {
+        // in v1.8.0 "lambda" integration check was removed because setting cache key parameters seemed to work for both AWS_PROXY and AWS (lambda) integration
+        // reconsider if this becomes an issue
+
+        // if (method.Properties.Integration.Type !== 'AWS_PROXY') {
           method.Properties.Integration.RequestParameters[`integration.${cacheKeyParameter.name}`] = `method.${cacheKeyParameter.name}`;
-        }
+        // }
 
         method.Properties.Integration.CacheKeyParameters.push(`method.${cacheKeyParameter.name}`);
       } else {
@@ -44,9 +47,9 @@ const addPathParametersCacheConfig = (settings, serverless) => {
         ) {
           method.Properties.RequestParameters[cacheKeyParameter.mappedFrom] = (existingValue == null || existingValue == undefined) ? {} : existingValue;
         }
-        if (method.Properties.Integration.Type !== 'AWS_PROXY') {
+        // if (method.Properties.Integration.Type !== 'AWS_PROXY') {
           method.Properties.Integration.RequestParameters[cacheKeyParameter.name] = cacheKeyParameter.mappedFrom;
-        }
+        // }
         method.Properties.Integration.CacheKeyParameters.push(cacheKeyParameter.name)
       }
     }

--- a/test/configuring-path-parameters.js
+++ b/test/configuring-path-parameters.js
@@ -41,6 +41,7 @@ describe('Configuring path parameter caching', () => {
     });
   });
 
+  // in v1.8.0 "lambda" integration check was removed because setting cache key parameters seemed to work for both AWS_PROXY and AWS (lambda) integration
   describe('when one endpoint with lambda integration has cache key parameters', () => {
     let cacheKeyParameters, method, functionWithCachingName;
     before(() => {
@@ -70,10 +71,10 @@ describe('Configuring path parameter caching', () => {
       }
     });
 
-    it('should not set any integration request parameters', () => {
+    it('should set integration request parameters', () => {
       for (let parameter of cacheKeyParameters) {
         expect(method.Properties.Integration.RequestParameters)
-          .to.not.include({
+          .to.include({
             [`integration.${parameter.name}`]: `method.${parameter.name}`
           });
       }


### PR DESCRIPTION
Using the body as a cache key parameter works when using AWS_PROXY rather than AWS (lambda) integration according to my latest tests.