### PR TITLE
fix call on non-init settings object

### DIFF
--- a/src/apiGatewayCachingPlugin.js
+++ b/src/apiGatewayCachingPlugin.js
@@ -41,14 +41,14 @@ class ApiGatewayCachingPlugin {
   }
 
   async updateStage() {
+    if (!this.settings) {
+      this.createSettings()
+    }
+
     this.thereIsARestApi = await restApiExists(this.serverless, this.settings);
     if (!this.thereIsARestApi) {
       this.serverless.cli.log(`[serverless-api-gateway-caching] No REST API found. Caching settings will not be updated.`);
       return;
-    }
-
-    if (!this.settings) {
-      this.createSettings()
     }
 
     return updateStageCacheSettings(this.settings, this.serverless);

--- a/src/restApiId.js
+++ b/src/restApiId.js
@@ -41,8 +41,8 @@ const outputRestApiIdTo = (serverless) => {
 };
 
 const getAlreadyDeployedStack = async (serverless, settings) => {
-  const stackName = serverless.providers.aws.naming.getStackName(settings.stage);
   try {
+    const stackName = serverless.providers.aws.naming.getStackName(settings.stage);
     const stack = await serverless.providers.aws.request('CloudFormation', 'describeStacks', { StackName: stackName },
       settings.stage,
       settings.region

--- a/test/creating-plugin.js
+++ b/test/creating-plugin.js
@@ -73,7 +73,7 @@ describe('Creating plugin', () => {
         thereIsARestApi: false,
         expectedLogMessage: '[serverless-api-gateway-caching] No REST API found. Caching settings will not be updated.',
         expectedToUpdateStageCache: false,
-        expectedToHaveSettings: false
+        expectedToHaveSettings: true
       },
       {
         description: 'there is a REST API',


### PR DESCRIPTION
When deploying saw this kind of error

`TypeError: Cannot read properties of undefined (reading 'stage')
    at getAlreadyDeployedStack (/builds/.../serverless-api-gateway-caching/src/restApiId.js:44:75)
    at restApiExists (/builds/.../serverless-api-gateway-caching/src/restApiId.js:23:23)
    at ApiGatewayCachingPlugin.updateStage (/builds/.../serverless-api-gateway-caching/src/apiGatewayCachingPlugin.js:44:34)
    at PluginManager.runHooks (/builds/.../serverless/lib/classes/plugin-manager.js:530:15)
    at PluginManager.invoke (/builds/.../serverless/lib/classes/plugin-manager.js:565:20)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at PluginManager.spawn (/builds/.../serverless/lib/classes/plugin-manager.js:585:5)
    at PluginManager.runHooks (/builds/.../serverless/lib/classes/plugin-manager.js:530:9)
    at PluginManager.invoke (/builds/.../serverless/lib/classes/plugin-manager.js:564:9)
    at PluginManager.run (/builds/.../serverless/lib/classes/plugin-manager.js:604:7)
    at Serverless.run (/builds/.../serverless/lib/serverless.js:179:5)
    at /builds/.../serverless/scripts/serverless.js:812:9
`

Debugging through the plugin code made me think it was a mistake to:
1 call getAlreadyDeployedStack with the settings object parameter, which is possibly undefined, and use `settings.stage` call if even it is called;
2 to invoke `await restApiExists(this.serverless, this.settings);` call before 
`if (!this.settings) {
      this.createSettings()
    }`


Pull request consists of function reordering and test case fix