### PR TITLE
Change default value of Method RequestParameters from {} to true

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-api-gateway-caching",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-api-gateway-caching",
-      "version": "1.10.2",
+      "version": "1.10.3",
       "license": "ISC",
       "dependencies": {
         "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-gateway-caching",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "A plugin for the serverless framework which helps with configuring caching for API Gateway endpoints.",
   "main": "src/apiGatewayCachingPlugin.js",
   "scripts": {

--- a/src/cacheKeyParameters.js
+++ b/src/cacheKeyParameters.js
@@ -28,7 +28,7 @@ const applyCacheKeyParameterSettings = (settings, serverless) => {
     for (let cacheKeyParameter of endpointSettings.cacheKeyParameters) {
       if (!cacheKeyParameter.mappedFrom) {
         let existingValue = method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`];
-        method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = (existingValue == null || existingValue == undefined) ? {} : existingValue;
+        method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = (existingValue == null || existingValue == undefined) ? false : existingValue;
 
         // without this check, endpoints 500 when using cache key parameters like "Authorization" or headers with the same characters in different casing (e.g. "origin" and "Origin")
         if (method.Properties.Integration.Type !== 'AWS_PROXY') {
@@ -43,7 +43,7 @@ const applyCacheKeyParameterSettings = (settings, serverless) => {
           cacheKeyParameter.mappedFrom.includes('method.request.header') ||
           cacheKeyParameter.mappedFrom.includes('method.request.path')
         ) {
-          method.Properties.RequestParameters[cacheKeyParameter.mappedFrom] = (existingValue == null || existingValue == undefined) ? {} : existingValue;
+          method.Properties.RequestParameters[cacheKeyParameter.mappedFrom] = (existingValue == null || existingValue == undefined) ? false : existingValue;
         }
 
         // in v1.8.0 "lambda" integration check was removed because setting cache key parameters seemed to work for both AWS_PROXY and AWS (lambda) integration

--- a/src/cacheKeyParameters.js
+++ b/src/cacheKeyParameters.js
@@ -28,7 +28,7 @@ const applyCacheKeyParameterSettings = (settings, serverless) => {
     for (let cacheKeyParameter of endpointSettings.cacheKeyParameters) {
       if (!cacheKeyParameter.mappedFrom) {
         let existingValue = method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`];
-        method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = (existingValue == null || existingValue == undefined) ? false : existingValue;
+        method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = (existingValue == null || existingValue == undefined) ? true : existingValue;
 
         // without this check, endpoints 500 when using cache key parameters like "Authorization" or headers with the same characters in different casing (e.g. "origin" and "Origin")
         if (method.Properties.Integration.Type !== 'AWS_PROXY') {
@@ -43,7 +43,7 @@ const applyCacheKeyParameterSettings = (settings, serverless) => {
           cacheKeyParameter.mappedFrom.includes('method.request.header') ||
           cacheKeyParameter.mappedFrom.includes('method.request.path')
         ) {
-          method.Properties.RequestParameters[cacheKeyParameter.mappedFrom] = (existingValue == null || existingValue == undefined) ? false : existingValue;
+          method.Properties.RequestParameters[cacheKeyParameter.mappedFrom] = (existingValue == null || existingValue == undefined) ? true : existingValue;
         }
 
         // in v1.8.0 "lambda" integration check was removed because setting cache key parameters seemed to work for both AWS_PROXY and AWS (lambda) integration

--- a/test/configuring-cache-key-parameters-for-additional-endpoints.js
+++ b/test/configuring-cache-key-parameters-for-additional-endpoints.js
@@ -54,7 +54,7 @@ describe('Configuring path parameters for additional endpoints defined as CloudF
             for (let parameter of cacheKeyParameters) {
                 expect(apiGatewayMethod.Properties.RequestParameters)
                     .to.deep.include({
-                        [`method.${parameter.name}`]: {}
+                        [`method.${parameter.name}`]: false
                     });
             }
         });

--- a/test/configuring-cache-key-parameters-for-additional-endpoints.js
+++ b/test/configuring-cache-key-parameters-for-additional-endpoints.js
@@ -54,7 +54,7 @@ describe('Configuring path parameters for additional endpoints defined as CloudF
             for (let parameter of cacheKeyParameters) {
                 expect(apiGatewayMethod.Properties.RequestParameters)
                     .to.deep.include({
-                        [`method.${parameter.name}`]: false
+                        [`method.${parameter.name}`]: true
                     });
             }
         });

--- a/test/configuring-cache-key-parameters.js
+++ b/test/configuring-cache-key-parameters.js
@@ -65,7 +65,7 @@ describe('Configuring cache key parameters', () => {
       for (let parameter of cacheKeyParameters) {
         expect(method.Properties.RequestParameters)
           .to.deep.include({
-            [`method.${parameter.name}`]: false
+            [`method.${parameter.name}`]: true
           });
       }
     });
@@ -123,7 +123,7 @@ describe('Configuring cache key parameters', () => {
         for (let parameter of cacheKeyParameters) {
           expect(method.Properties.RequestParameters)
             .to.deep.include({
-              [`method.${parameter.name}`]: false
+              [`method.${parameter.name}`]: true
             });
         }
       });
@@ -203,7 +203,7 @@ describe('Configuring cache key parameters', () => {
         for (let parameter of cacheKeyParameters) {
           expect(method.Properties.RequestParameters)
             .to.deep.include({
-              [`method.${parameter.name}`]: false
+              [`method.${parameter.name}`]: true
             });
         }
       });
@@ -308,7 +308,7 @@ describe('Configuring cache key parameters', () => {
           for (let parameter of firstEndpointCacheKeyParameters) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [`method.${parameter.name}`]: false
+                [`method.${parameter.name}`]: true
               });
           }
         });
@@ -343,7 +343,7 @@ describe('Configuring cache key parameters', () => {
           for (let parameter of secondEndpointCacheKeyParameters) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [`method.${parameter.name}`]: false
+                [`method.${parameter.name}`]: true
               });
           }
         });
@@ -399,7 +399,7 @@ describe('Configuring cache key parameters', () => {
         for (let parameter of firstEndpointCacheKeyParameters) {
           expect(method.Properties.RequestParameters)
             .to.deep.include({
-              [`method.${parameter.name}`]: false
+              [`method.${parameter.name}`]: true
             });
         }
       });
@@ -434,7 +434,7 @@ describe('Configuring cache key parameters', () => {
         for (let parameter of secondEndpointCacheKeyParameters) {
           expect(method.Properties.RequestParameters)
             .to.deep.include({
-              [`method.${parameter.name}`]: false
+              [`method.${parameter.name}`]: true
             });
         }
       });
@@ -506,7 +506,7 @@ describe('Configuring cache key parameters', () => {
           for (let parameter of cacheKeyParameters) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [`method.${parameter.name}`]: false
+                [`method.${parameter.name}`]: true
               });
           }
         });
@@ -568,7 +568,7 @@ describe('Configuring cache key parameters', () => {
           ) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [parameter.mappedFrom]: false
+                [parameter.mappedFrom]: true
               });
           }
         }
@@ -609,7 +609,7 @@ describe('Configuring cache key parameters', () => {
           ) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [parameter.mappedFrom]: false
+                [parameter.mappedFrom]: true
               });
           }
         }

--- a/test/configuring-cache-key-parameters.js
+++ b/test/configuring-cache-key-parameters.js
@@ -65,7 +65,7 @@ describe('Configuring cache key parameters', () => {
       for (let parameter of cacheKeyParameters) {
         expect(method.Properties.RequestParameters)
           .to.deep.include({
-            [`method.${parameter.name}`]: {}
+            [`method.${parameter.name}`]: false
           });
       }
     });
@@ -123,7 +123,7 @@ describe('Configuring cache key parameters', () => {
         for (let parameter of cacheKeyParameters) {
           expect(method.Properties.RequestParameters)
             .to.deep.include({
-              [`method.${parameter.name}`]: {}
+              [`method.${parameter.name}`]: false
             });
         }
       });
@@ -203,7 +203,7 @@ describe('Configuring cache key parameters', () => {
         for (let parameter of cacheKeyParameters) {
           expect(method.Properties.RequestParameters)
             .to.deep.include({
-              [`method.${parameter.name}`]: {}
+              [`method.${parameter.name}`]: false
             });
         }
       });
@@ -308,7 +308,7 @@ describe('Configuring cache key parameters', () => {
           for (let parameter of firstEndpointCacheKeyParameters) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [`method.${parameter.name}`]: {}
+                [`method.${parameter.name}`]: false
               });
           }
         });
@@ -343,7 +343,7 @@ describe('Configuring cache key parameters', () => {
           for (let parameter of secondEndpointCacheKeyParameters) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [`method.${parameter.name}`]: {}
+                [`method.${parameter.name}`]: false
               });
           }
         });
@@ -399,7 +399,7 @@ describe('Configuring cache key parameters', () => {
         for (let parameter of firstEndpointCacheKeyParameters) {
           expect(method.Properties.RequestParameters)
             .to.deep.include({
-              [`method.${parameter.name}`]: {}
+              [`method.${parameter.name}`]: false
             });
         }
       });
@@ -434,7 +434,7 @@ describe('Configuring cache key parameters', () => {
         for (let parameter of secondEndpointCacheKeyParameters) {
           expect(method.Properties.RequestParameters)
             .to.deep.include({
-              [`method.${parameter.name}`]: {}
+              [`method.${parameter.name}`]: false
             });
         }
       });
@@ -506,7 +506,7 @@ describe('Configuring cache key parameters', () => {
           for (let parameter of cacheKeyParameters) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [`method.${parameter.name}`]: {}
+                [`method.${parameter.name}`]: false
               });
           }
         });
@@ -568,7 +568,7 @@ describe('Configuring cache key parameters', () => {
           ) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [parameter.mappedFrom]: {}
+                [parameter.mappedFrom]: false
               });
           }
         }
@@ -609,7 +609,7 @@ describe('Configuring cache key parameters', () => {
           ) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [parameter.mappedFrom]: {}
+                [parameter.mappedFrom]: false
               });
           }
         }


### PR DESCRIPTION
Per the [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-method.html#cfn-apigateway-method-requestparameters), method.Properties.RequestParameters only accepts a string;boolean pair object.
The issue:
When using the plugin like:
```yaml
events:
  - http:
      path: pathPart
      method: get
      cors: true
      caching:
        enabled: true
        cacheKeyParameters:
          - name: request.querystring.limit
          - name: request.header.Accept
          - name: request.header.Authorization
```
The plugin modifies the cloudformation: 
```json
"ApiGatewayMethodMyApiGet": {
  "Type": "AWS::ApiGateway::Method",
  "Properties": {
    "HttpMethod": "GET",
    "RequestParameters": {
      "method.request.querystring.limit": {},
      "method.request.header.Accept": {},
      "method.request.header.Authorization": {}
    },
```

Which leads to the following error:
```
Properties validation failed for resource ApiGatewayMethodMyApiGet with message:
#/RequestParameters/method.request.header.Accept: #: no subschema matched out of the total 2 subschemas
#/RequestParameters/method.request.header.Accept: expected type: Boolean, found: JSONObject
#/RequestParameters/method.request.header.Accept: expected type: String, found: JSONObject
#/RequestParameters/method.request.querystring.limit: #: no subschema matched out of the total 2 subschemas
#/RequestParameters/method.request.querystring.limit: expected type: Boolean, found: JSONObject
#/RequestParameters/method.request.querystring.limit: expected type: String, found: JSONObject
#/RequestParameters/method.request.header.Authorization: #: no subschema matched out of the total 2 subschemas
#/RequestParameters/method.request.header.Authorization: expected type: Boolean, found: JSONObject
#/RequestParameters/method.request.header.Authorization: expected type: String, found: JSONObject

```

This PR changes the default values to `true` instead of `{}` and updates related unit tests.