### PR TITLE
Add optional `required` configuration to parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,41 @@ functions:
                 mappedFrom: method.request.body.cities[0].petCount
 ```
 
+### Requiring cache key parameters
+When adding a cache key parameter you can specify whether the parameter is required for the function.
+
+By default cache key parameters are **not** required.
+
+In this example:
+
+```yml
+plugins:
+  - serverless-api-gateway-caching
+
+custom:
+  apiGatewayCaching:
+    enabled: true
+
+functions:
+  get-cats:
+    handler: rest_api/cat/get/handler.handle
+    events:
+      - http:
+          path: /cats
+          method: get
+          caching:
+            enabled: true
+            cacheKeyParameters:
+              - name: request.querystring.breed
+              - name: request.querystring.furColour
+                required: false
+              - name: request.header.Accept-Language
+                required: true
+```
+
+- The `breed` and `furColour` are **optional**.
+- The `Accept-Language` header is **required**. It must be included with the request or the function will fail.
+
 ### Limitations
 Cache key parameters coming from multi-value query strings and multi-value headers are currently not supported.
 

--- a/src/cacheKeyParameters.js
+++ b/src/cacheKeyParameters.js
@@ -26,9 +26,10 @@ const applyCacheKeyParameterSettings = (settings, serverless) => {
     }
 
     for (let cacheKeyParameter of endpointSettings.cacheKeyParameters) {
+      let isRequired = cacheKeyParameter.required || false;
       if (!cacheKeyParameter.mappedFrom) {
         let existingValue = method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`];
-        method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = (existingValue == null || existingValue == undefined) ? true : existingValue;
+        method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = (existingValue == null || existingValue == undefined) ? isRequired : existingValue;
 
         // without this check, endpoints 500 when using cache key parameters like "Authorization" or headers with the same characters in different casing (e.g. "origin" and "Origin")
         if (method.Properties.Integration.Type !== 'AWS_PROXY') {
@@ -43,7 +44,7 @@ const applyCacheKeyParameterSettings = (settings, serverless) => {
           cacheKeyParameter.mappedFrom.includes('method.request.header') ||
           cacheKeyParameter.mappedFrom.includes('method.request.path')
         ) {
-          method.Properties.RequestParameters[cacheKeyParameter.mappedFrom] = (existingValue == null || existingValue == undefined) ? true : existingValue;
+          method.Properties.RequestParameters[cacheKeyParameter.mappedFrom] = (existingValue == null || existingValue == undefined) ? isRequired : existingValue;
         }
 
         // in v1.8.0 "lambda" integration check was removed because setting cache key parameters seemed to work for both AWS_PROXY and AWS (lambda) integration


### PR DESCRIPTION
Changes made in #132 made all `cacheKeyParameters` values required by default but previously this was not the case. This breaks functions that rely on cache key parameters based on optional headers/query strings/etc.

This is an implementation of @geetchoubey's recommendation from https://github.com/DianaIonita/serverless-api-gateway-caching/pull/132#issuecomment-1816712698.

This change allows a config like this:

```yaml
# serverless.yml
cors: true
caching:
  enabled: true
  cacheKeyParameters:
    - name: request.querystring.required # Final value in API GW: True
      required: true
    - name: request.querystring.notrequired # Final value in API GW:  False
      required: false
    - name: request.querystring.letssee # Final value in API GW:  False
```

And the `required` value defaults to `false` so backwards compatibility is maintained with versions before this bug was introduced in `1.10.3`.

Fixes #133 