### PR TITLE
Change default value of Method RequestParameters from true to false

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-api-gateway-caching",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-api-gateway-caching",
-      "version": "1.10.3",
+      "version": "1.10.4",
       "license": "ISC",
       "dependencies": {
         "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-gateway-caching",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "A plugin for the serverless framework which helps with configuring caching for API Gateway endpoints.",
   "main": "src/apiGatewayCachingPlugin.js",
   "scripts": {

--- a/src/cacheKeyParameters.js
+++ b/src/cacheKeyParameters.js
@@ -28,7 +28,7 @@ const applyCacheKeyParameterSettings = (settings, serverless) => {
     for (let cacheKeyParameter of endpointSettings.cacheKeyParameters) {
       if (!cacheKeyParameter.mappedFrom) {
         let existingValue = method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`];
-        method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = (existingValue == null || existingValue == undefined) ? true : existingValue;
+        method.Properties.RequestParameters[`method.${cacheKeyParameter.name}`] = (existingValue == null || existingValue == undefined) ? false : existingValue;
 
         // without this check, endpoints 500 when using cache key parameters like "Authorization" or headers with the same characters in different casing (e.g. "origin" and "Origin")
         if (method.Properties.Integration.Type !== 'AWS_PROXY') {
@@ -43,7 +43,7 @@ const applyCacheKeyParameterSettings = (settings, serverless) => {
           cacheKeyParameter.mappedFrom.includes('method.request.header') ||
           cacheKeyParameter.mappedFrom.includes('method.request.path')
         ) {
-          method.Properties.RequestParameters[cacheKeyParameter.mappedFrom] = (existingValue == null || existingValue == undefined) ? true : existingValue;
+          method.Properties.RequestParameters[cacheKeyParameter.mappedFrom] = (existingValue == null || existingValue == undefined) ? false : existingValue;
         }
 
         // in v1.8.0 "lambda" integration check was removed because setting cache key parameters seemed to work for both AWS_PROXY and AWS (lambda) integration

--- a/test/configuring-cache-key-parameters-for-additional-endpoints.js
+++ b/test/configuring-cache-key-parameters-for-additional-endpoints.js
@@ -54,7 +54,7 @@ describe('Configuring path parameters for additional endpoints defined as CloudF
             for (let parameter of cacheKeyParameters) {
                 expect(apiGatewayMethod.Properties.RequestParameters)
                     .to.deep.include({
-                        [`method.${parameter.name}`]: true
+                        [`method.${parameter.name}`]: false
                     });
             }
         });

--- a/test/configuring-cache-key-parameters.js
+++ b/test/configuring-cache-key-parameters.js
@@ -65,7 +65,7 @@ describe('Configuring cache key parameters', () => {
       for (let parameter of cacheKeyParameters) {
         expect(method.Properties.RequestParameters)
           .to.deep.include({
-            [`method.${parameter.name}`]: true
+            [`method.${parameter.name}`]: false
           });
       }
     });
@@ -123,7 +123,7 @@ describe('Configuring cache key parameters', () => {
         for (let parameter of cacheKeyParameters) {
           expect(method.Properties.RequestParameters)
             .to.deep.include({
-              [`method.${parameter.name}`]: true
+              [`method.${parameter.name}`]: false
             });
         }
       });
@@ -203,7 +203,7 @@ describe('Configuring cache key parameters', () => {
         for (let parameter of cacheKeyParameters) {
           expect(method.Properties.RequestParameters)
             .to.deep.include({
-              [`method.${parameter.name}`]: true
+              [`method.${parameter.name}`]: false
             });
         }
       });
@@ -308,7 +308,7 @@ describe('Configuring cache key parameters', () => {
           for (let parameter of firstEndpointCacheKeyParameters) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [`method.${parameter.name}`]: true
+                [`method.${parameter.name}`]: false
               });
           }
         });
@@ -343,7 +343,7 @@ describe('Configuring cache key parameters', () => {
           for (let parameter of secondEndpointCacheKeyParameters) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [`method.${parameter.name}`]: true
+                [`method.${parameter.name}`]: false
               });
           }
         });
@@ -399,7 +399,7 @@ describe('Configuring cache key parameters', () => {
         for (let parameter of firstEndpointCacheKeyParameters) {
           expect(method.Properties.RequestParameters)
             .to.deep.include({
-              [`method.${parameter.name}`]: true
+              [`method.${parameter.name}`]: false
             });
         }
       });
@@ -434,7 +434,7 @@ describe('Configuring cache key parameters', () => {
         for (let parameter of secondEndpointCacheKeyParameters) {
           expect(method.Properties.RequestParameters)
             .to.deep.include({
-              [`method.${parameter.name}`]: true
+              [`method.${parameter.name}`]: false
             });
         }
       });
@@ -506,7 +506,7 @@ describe('Configuring cache key parameters', () => {
           for (let parameter of cacheKeyParameters) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [`method.${parameter.name}`]: true
+                [`method.${parameter.name}`]: false
               });
           }
         });
@@ -568,7 +568,7 @@ describe('Configuring cache key parameters', () => {
           ) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [parameter.mappedFrom]: true
+                [parameter.mappedFrom]: false
               });
           }
         }
@@ -609,7 +609,7 @@ describe('Configuring cache key parameters', () => {
           ) {
             expect(method.Properties.RequestParameters)
               .to.deep.include({
-                [parameter.mappedFrom]: true
+                [parameter.mappedFrom]: false
               });
           }
         }


### PR DESCRIPTION
Changes made in the [1.10.3](https://github.com/DianaIonita/serverless-api-gateway-caching/releases/tag/1.10.3) release made cache-key parameters required by default, changing the behaviour from 1.10.2 and introducing a breaking change.

This PR addresses the last comment by @DianaIonita in #134 suggesting we go back to making cache-key parameters optional by default, whilst still being able to make them required via `events.http.request.parameters`:

> Hi everyone,
>
> This is my suggestion:
> 
> set the default of not required on cache key parameters
> if anyone wants to require cache key parametres, they can do it via the already existing serverless framework config (events.http.request.parameters)
> This way, we avoid the confusion of having two config options that do the same thing. It also doesn't need the developer to remember any special behaviours of this caching plugin.

Fixes #133 